### PR TITLE
Medium perf

### DIFF
--- a/src/ChipSort.jl
+++ b/src/ChipSort.jl
@@ -3,7 +3,7 @@ import Base.pop!
 
 export
     sort_net,
-    transpose_vecs, transpose_vecs_tall, transpose_vecs_wide,
+    transpose_vecs, transpose_vecs_tall, transpose_vecs_wide, transpose!,
     bitonic_merge, merge_vecs, build_multi_merger, bitonic_merge_interleaved,
     DataBuffer, MergeNode, pop!,
     chipsort, chipsort_medium!, sort_chunks, sort_vecs!, merge_vecs_tree, sort_small_array, combsort!, insertion_sort!

--- a/src/ChipSort.jl
+++ b/src/ChipSort.jl
@@ -6,7 +6,7 @@ export
     transpose_vecs, transpose_vecs_tall, transpose_vecs_wide,
     bitonic_merge, merge_vecs, build_multi_merger, bitonic_merge_interleaved,
     DataBuffer, MergeNode, pop!,
-    chipsort, sort_chunks, chipsort_medium, merge_vecs_tree, sort_small_array
+    chipsort, chipsort_medium!, sort_chunks, sort_vecs!, merge_vecs_tree, sort_small_array, combsort!, insertion_sort!
 
 
 include("utils.jl")
@@ -15,6 +15,7 @@ include("transpose-vecs.jl")
 include("bitonic-merge-network.jl")
 include("data-buffers.jl")
 include("sort-array.jl")
+include("comb-sort.jl")
 include("sort-array-medium.jl")
 
 end # module

--- a/src/ChipSort.jl
+++ b/src/ChipSort.jl
@@ -3,7 +3,7 @@ import Base.pop!
 
 export
     sort_net,
-    transpose_vecs, transpose_vecs_tall, transpose_vecs_wide, transpose!,
+    transpose_vecs, transpose_chunks!, transpose_vecs_tall, transpose_vecs_wide, transpose!,
     bitonic_merge, merge_vecs, build_multi_merger, bitonic_merge_interleaved,
     DataBuffer, MergeNode, pop!,
     chipsort, chipsort_medium!, sort_chunks, sort_vecs!, merge_vecs_tree, sort_small_array, combsort!, insertion_sort!,

--- a/src/ChipSort.jl
+++ b/src/ChipSort.jl
@@ -6,7 +6,8 @@ export
     transpose_vecs, transpose_chunks!, transpose_vecs_tall, transpose_vecs_wide, transpose!,
     bitonic_merge, merge_vecs, build_multi_merger, bitonic_merge_interleaved,
     DataBuffer, MergeNode, pop!,
-    chipsort, chipsort_medium!, sort_chunks, sort_vecs!, merge_vecs_tree, sort_small_array, combsort!, insertion_sort!,
+    chipsort, chipsort_medium!, chipsort_medium_old, sort_chunks, sort_vecs!,
+    merge_vecs_tree, sort_small_array, combsort!, insertion_sort!,
     chipsort_merge_medium
 
 

--- a/src/ChipSort.jl
+++ b/src/ChipSort.jl
@@ -6,7 +6,8 @@ export
     transpose_vecs, transpose_vecs_tall, transpose_vecs_wide, transpose!,
     bitonic_merge, merge_vecs, build_multi_merger, bitonic_merge_interleaved,
     DataBuffer, MergeNode, pop!,
-    chipsort, chipsort_medium!, sort_chunks, sort_vecs!, merge_vecs_tree, sort_small_array, combsort!, insertion_sort!
+    chipsort, chipsort_medium!, sort_chunks, sort_vecs!, merge_vecs_tree, sort_small_array, combsort!, insertion_sort!,
+    chipsort_merge_medium
 
 
 include("utils.jl")

--- a/src/bitonic-merge-network.jl
+++ b/src/bitonic-merge-network.jl
@@ -179,7 +179,7 @@ Merges K pairs of vectors using a bitonic sort network, with interleaved executi
     input::Array{Ptr{T},1},
     ::Val{V},
     J,
-    ::Val{K},
+    ::Val{K}
 ) where {T,V,K}
 
     allex = []

--- a/src/bitonic-merge-network.jl
+++ b/src/bitonic-merge-network.jl
@@ -77,6 +77,65 @@ Merges two `SIMD.Vec` objects of the same type and size using a bitonic sort net
 end
 
 
+"""
+    bitonic_merge(input_a::Vec{N,T}, input_b::Vec{N,T}) where {N,T}
+
+Merges two `SIMD.Vec` objects of the same type and size using a bitonic sort network. The inputs are assumed to be sorted. Returns a pair of vectors with the first and second halves of the merged sequence.
+"""
+@generated function bitonic_merge2(input_a::Vec{N,T}, input_b, output) where {N,T}
+
+    pat = Val{ntuple(x->N-x, N)}
+
+    ex = [
+        Expr(:meta, :inline),
+        :(la_0 = input_a),
+        :(lb_0 = shufflevector(vload(Vec{N,T},input_b), $pat)),
+        :(L_0 = min(la_0, lb_0)),
+        :(H_0 = max(la_0, lb_0))
+    ]
+
+    p = mylog(N)
+    for n in 1:p
+        la = Symbol("la_", n)
+        lb = Symbol("lb_", n)
+        Lp = Symbol("L_", n-1)
+        Hp = Symbol("H_", n-1)
+        L = Symbol("L_", n)
+        H = Symbol("H_", n)
+
+        ih = inverse_shuffle(bitonic_step(2^(n), 2^(p-n+1)))
+        sh = bitonic_step(2^(n+1), 2^(p-n))
+        pat_a = Val{tuple((ih[sh[1:N]].-1)...)}
+        pat_b = Val{tuple((ih[sh[(N+1):end]].-1)...)}
+
+        append!(ex, [
+            :($la = shufflevector($Lp, $Hp, $pat_a)),
+            :($lb = shufflevector($Lp, $Hp, $pat_b)),
+            :($L = min($la, $lb)),
+            :($H = max($la, $lb))
+        ])
+    end
+
+    la = Symbol("la_", p+1)
+    lb = Symbol("lb_", p+1)
+    Lp = Symbol("L_", p)
+    Hp = Symbol("H_", p)
+
+    ih = inverse_shuffle(bitonic_step(2N, 1))
+    pat_a = Val{tuple((ih[1:N].-1)...)}
+    pat_b = Val{tuple((ih[(N+1):end].-1)...)}
+
+    append!(ex, [
+        :($la = shufflevector($Lp, $Hp, $pat_a)),
+        :($lb = shufflevector($Lp, $Hp, $pat_b)),
+        :(vstore($la, output)),
+        :(return $lb)
+    ])
+
+    quote $(ex...) end
+end
+
+
 @inline function bitonic_merge_concat(input_a::Vec{N,T}, input_b::Vec{N,T})::Vec{2*N,T} where {N,T}
     m_a, m_b = bitonic_merge(input_a, input_b)
     concat(m_a, m_b)

--- a/src/comb-sort.jl
+++ b/src/comb-sort.jl
@@ -9,38 +9,19 @@ using SIMD
 """
 function chipsort_medium!(input::AbstractVector{T}, ::Val{V}, ::Val{J}, ::Val{K}) where {T,V,J,K}
 
-    # println("input")
-    # display(reshape(input, V,:))
-
     sort_vecs!(input, Val(J), Val(V), Val(true))
-    # println("sortvecs")
-    # display(reshape(input, J,:))
 
     vectorized_combsort!(input, Val(J))
-    # println("combsort")
-    # display(reshape(input, J,:))
 
     transpose_chunks!(input, Val(V), Val(J))
-    # println("transchunks")
-    # display(reshape(input, J,:))
+
     transpose!(input, Val(V), Val(K), Val(J))
-    # input .= transpose(reshape(input, J, :))[:]
-    # println("trans")
-    # display(reshape(input, J,:))
 
     vectorized_combsort!(input, Val(J))
-    # println("combsort2")
-    # display(reshape(input, J,:))
 
     sort_vecs!(input, Val(V), Val(J), Val(false))
-    # println("sortvecs2")
-    # display(reshape(input, J,:))
 
     insertion_sort!(input)
-    # println("insertionsrt")
-    # combsort!(input, 1+div(2*length(input), J))
-    # println("combosrt2")
-    # display(reshape(input, V,:))
 
     input
 end

--- a/src/comb-sort.jl
+++ b/src/comb-sort.jl
@@ -1,0 +1,136 @@
+using SIMD
+
+
+"""Medium arrays are supposed to be as big as cache L1 or L2. Our recipe is:
+ - Generate small sorted vectors.
+ - Use vectorized Comb sort.
+ - Transpose in-place.
+ - Finish with insertion sort over the nearly sorted array.
+"""
+function chipsort_medium!(input::AbstractArray{T,1}, ::Val{V}, ::Val{L}) where {T,V,L}
+
+    # println("input")
+    # display(reshape(input, V,:))
+
+    sort_vecs!(input, Val(L), Val(V), Val(true))
+    # println("sortvecs")
+    # display(reshape(input, L,:))
+
+    vectorized_combsort!(input, Val(L))
+    # println("combsort")
+    # display(reshape(input, L,:))
+
+    input .= transpose(reshape(input, L, :))[:]
+    # println("trans")
+    # display(reshape(input, L,:))
+
+    vectorized_combsort!(input, Val(L))
+    # println("combsort2")
+    # display(reshape(input, L,:))
+
+    sort_vecs!(input, Val(V), Val(L), Val(false))
+    # println("sortvecs2")
+    # display(reshape(input, L,:))
+
+    insertion_sort!(input)
+    # println("insertionsrt")
+    # combsort!(input, 1+div(2*length(input), L))
+    # println("combosrt2")
+    # display(reshape(input, V,:))
+
+    input
+end
+
+function vectorized_combsort!(input::AbstractArray{T,1}, ::Val{V}) where {T,V}
+    la = length(input)
+
+    interval = 3 * div(la, 32) * 8
+
+    logV = vallog(Val(V))
+    interval = (la >> (2+logV)) * (3 * V)
+
+    while interval > 0
+        ap = pointer(input,1)
+        finalp = pointer(input, la-interval)
+        while ap < finalp
+            a1 = vloada(Vec{V,T}, ap)
+            a2 = vloada(Vec{V,T}, ap + interval*sizeof(T))
+            b1 = min(a1, a2)
+            b2 = max(a1, a2)
+            vstorea(b1, ap)
+            vstorea(b2, ap + interval*sizeof(T))
+            ap = ap + V * sizeof(T)
+        end
+        interval = if interval==V 0 else max(V, (interval >> (2+logV)) * (3 * V)) end
+    end
+
+    input
+end
+
+
+"""Insertion sort, adapted from the Julia codebase."""
+@inline function insertion_sort!(v::AbstractVector)
+    lo, hi = 1, length(v)
+    # madi = 0
+    # culprit = 0
+    @inbounds for i = lo+1:hi
+        j = i
+        x = v[i]
+        while j > lo
+            if x <= v[j-1]
+                # if madi < i-j
+                    # madi = max(madi, i-j)
+                    # culprit = x
+                # end
+                v[j] = v[j-1]
+                j -= 1
+                continue
+            end
+            break
+        end
+        v[j] = x
+    end
+    # @show madi, culprit
+    return v
+end
+
+
+"""Regular version of Comb sort."""
+function combsort!(input::AbstractArray{T,1}, initial_interval=nothing::Union{Nothing,Int}) where T
+
+    la = length(input)
+    interval = if (initial_interval == nothing)
+        (3 * la) >> 2
+    else
+        initial_interval
+    end
+
+    @inbounds while interval > 1
+        # @show 2, interval
+        for i in 1:la-interval
+            a1 = input[i]
+            a2 = input[i+interval]
+            input[i] = min(a1, a2)
+            input[i+interval] = max(a1, a2)
+        end
+        interval = (3 * interval) >> 2
+    end
+
+    change = true
+    interval=1
+    @inbounds while change
+        # @show 3, interval
+        change = false
+        for i in 1:la-1
+            if input[i] > input[i+1]
+                change = true
+                a1 = input[i]
+                a2 = input[i+interval]
+                input[i] = min(a1, a2)
+                input[i+interval] = max(a1, a2)
+            end
+        end
+    end
+
+    input
+end

--- a/src/comb-sort.jl
+++ b/src/comb-sort.jl
@@ -7,34 +7,38 @@ using SIMD
  - Transpose in-place.
  - Finish with insertion sort over the nearly sorted array.
 """
-function chipsort_medium!(input::AbstractArray{T,1}, ::Val{V}, ::Val{L}) where {T,V,L}
+function chipsort_medium!(input::AbstractVector{T}, ::Val{V}, ::Val{J}, ::Val{K}) where {T,V,J,K}
 
     # println("input")
     # display(reshape(input, V,:))
 
-    sort_vecs!(input, Val(L), Val(V), Val(true))
+    sort_vecs!(input, Val(J), Val(V), Val(true))
     # println("sortvecs")
-    # display(reshape(input, L,:))
+    # display(reshape(input, J,:))
 
-    vectorized_combsort!(input, Val(L))
+    vectorized_combsort!(input, Val(J))
     # println("combsort")
-    # display(reshape(input, L,:))
+    # display(reshape(input, J,:))
 
-    input .= transpose(reshape(input, L, :))[:]
+    transpose_chunks!(input, Val(V), Val(J))
+    # println("transchunks")
+    # display(reshape(input, J,:))
+    transpose!(input, Val(V), Val(K), Val(J))
+    # input .= transpose(reshape(input, J, :))[:]
     # println("trans")
-    # display(reshape(input, L,:))
+    # display(reshape(input, J,:))
 
-    vectorized_combsort!(input, Val(L))
+    # vectorized_combsort!(input, Val(J))
     # println("combsort2")
-    # display(reshape(input, L,:))
+    # display(reshape(input, J,:))
 
-    sort_vecs!(input, Val(V), Val(L), Val(false))
+    # sort_vecs!(input, Val(V), Val(J), Val(false))
     # println("sortvecs2")
-    # display(reshape(input, L,:))
+    # display(reshape(input, J,:))
 
-    insertion_sort!(input)
+    # insertion_sort!(input)
     # println("insertionsrt")
-    # combsort!(input, 1+div(2*length(input), L))
+    # combsort!(input, 1+div(2*length(input), J))
     # println("combosrt2")
     # display(reshape(input, V,:))
 

--- a/src/sort-array-medium.jl
+++ b/src/sort-array-medium.jl
@@ -39,12 +39,79 @@ function merge_vecs_tree(input::AbstractArray{T,A}, ::Val{C}, ::Val{N}, ::Val{L}
     end
 end
 
-function chipsort_medium(input::AbstractArray{T,A}, ::Val{C}, ::Val{N}, ::Val{L}) where {A,T,C,N,L}
+function chipsort_medium_old(input::AbstractArray{T,A}, ::Val{C}, ::Val{N}, ::Val{L}) where {A,T,C,N,L}
     output = valloc(T, div(32, sizeof(T)), size(input,1))
     p=1
     for chunk in merge_vecs_tree(input, Val(C), Val(N), Val(L))
-        vstorent(chunk, output, p)
+        vstore(chunk, output, p)
         p+=N*L
     end
     output
+end
+
+function chipsort_medium(input::AbstractArray{T,1}, ::Val{C}, ::Val{N}, ::Val{L}) where {T,C,N,L}
+    output = valloc(T, div(32,sizeof(T)), N*L*C)
+
+    K = N*L
+
+    for cc in 1:C
+        chunks = ntuple(l->vloada(Vec{N, T}, input, 1+(cc-1)*N*L + (l-1)*N), L)::NTuple{L,Vec{N,T}}
+        if L>1
+            srt = sort_small_array(chunks)
+        else
+            srt=chunks[1]
+        end
+        vstorea(srt, output, 1+(cc-1)*N*L)
+    end
+
+    input, output = output, valloc(T, div(32,sizeof(T)), N*L*C)
+
+    pairs = C
+    l = 1#L
+    n = N*L#N
+    while pairs > 1
+        K = n*l
+        pairs = pairs >> 1
+        for cc in 0:pairs-1
+            p1 = cc*2*K+1
+            p2 = cc*2*K+1+K
+            end1 = cc*2*K+1+K
+            end2 = cc*2*K+1+2*K
+            pout = cc*2*K+1
+            merge_pair2(output, input, pout, p1, p2, end1, end2, l,n,T)
+        end
+        l = l<<1
+        input, output = output, input
+    end
+    input
+end
+
+function merge_pair2(output, input, pout, p1, p2, end1, end2, L,N,T)
+    h1 = vloada(Vec{N, T}, input, p1)
+    h2 = vloada(Vec{N, T}, input, p2)
+
+    out, state = bitonic_merge(h1, h2)
+    vstorea(out, output, pout)
+    pout += N
+
+    p1 += N
+    p2 += N
+    h1 = vloada(Vec{N, T}, input, p1)
+    h2 = vloada(Vec{N, T}, input, p2)
+
+    for ii in 1:2*L-2
+        if p2>=end2 || p1 < end1 && h1[1] < h2[1]
+            out, state = bitonic_merge(state, h1)
+            p1 += N
+            h1 = vloada(Vec{N, T}, input, p1)
+        else
+            out, state = bitonic_merge(state, h2)
+            p2 += N
+            h2 = vloada(Vec{N, T}, input, p2)
+        end
+        vstorea(out, output, pout)
+        pout+=N
+    end
+    vstorea(state, output, pout)
+    nothing
 end

--- a/src/sort-array-medium.jl
+++ b/src/sort-array-medium.jl
@@ -49,210 +49,87 @@ function chipsort_medium_old(input::AbstractArray{T,A}, ::Val{C}, ::Val{N}, ::Va
     output
 end
 
-# function chipsort_medium(input::AbstractArray{T,1}, ::Val{C}, ::Val{N}, ::Val{L}) where {T,C,N,L}
-#     output = valloc(T, div(32,sizeof(T)), N*L*C)
 
-#     K = N*L
+function chipsort_medium(input::AbstractArray{T,1}, ::Val{V}, ::Val{J}, ::Val{K}) where {T,V,J,K}
+    output = valloc(T, div(32,sizeof(T)), V*J*K)
 
-#     for cc in 1:C
-#         chunks = ntuple(l->vloada(Vec{N, T}, input, 1+(cc-1)*N*L + (l-1)*N), L)::NTuple{L,Vec{N,T}}
-#         if L>1
-#             srt = sort_small_array(chunks)
-#         else
-#             srt=chunks[1]
-#         end
-#         vstorea(srt, output, 1+(cc-1)*N*L)
-#     end
-
-#     input, output = output, valloc(T, div(32,sizeof(T)), N*L*C)
-
-#     pairs = C
-#     l = 1#L
-#     n = N*L#N
-#     while pairs > 1
-#         K = n*l
-#         pairs = pairs >> 1
-#         for cc in 0:pairs-1
-#             p1 = cc*2*K+1
-#             p2 = cc*2*K+1+K
-#             end1 = cc*2*K+1+K
-#             end2 = cc*2*K+1+2*K
-#             pout = cc*2*K+1
-#             merge_pair2(output, input, pout, p1, p2, end1, end2, l,n,T)
-#         end
-#         l = l<<1
-#         input, output = output, input
-#     end
-#     input
-# end
-
-# function merge_pair2(output, input, pout, p1, p2, end1, end2, L,N,T)
-#     h1 = vloada(Vec{N, T}, input, p1)
-
-#     state = bitonic_merge2(h1, pointer(input, p2), pointer(output, pout))
-
-#     pout += N
-
-#     p1 += N
-#     p2 += N
-
-#     for ii in 1:2*L-2
-#         if p2>=end2 || p1 < end1 && input[p1] < input[p2]
-#             state = bitonic_merge2(state, pointer(input, p1), pointer(output, pout))
-#             p1 += N
-#         else
-#             state = bitonic_merge2(state, pointer(input, p2), pointer(output, pout))
-#             p2 += N
-#         end
-#         pout+=N
-#     end
-#     vstorea(state, output, pout)
-#     nothing
-# end
-
-
-
-
-
-function chipsort_medium(input::AbstractArray{T,1}, ::Val{C}, ::Val{N}, ::Val{L}) where {T,C,N,L}
-    output = valloc(T, div(32,sizeof(T)), N*L*C)
-
-    K = N*L
-
-    for cc in 1:C
-        chunks = ntuple(l->vloada(Vec{N, T}, input, 1+(cc-1)*N*L + (l-1)*N), L)::NTuple{L,Vec{N,T}}
-        if L>1
-            srt = sort_small_array(chunks)
-        else
-            srt=chunks[1]
+    if J>1
+        for cc in 1:K
+            chunks = ntuple(l->vloada(Vec{V, T}, input, 1+(cc-1)*V*J + (l-1)*V), J) ::NTuple{J, Vec{V,T}}
+            srt = sort_small_array(chunks) ::Vec{V*J,T}
+            vstorea(srt, output, 1+(cc-1)*V*J)
         end
-        vstorea(srt, output, 1+(cc-1)*N*L)
+    else
+        for cc in 1:K
+            chunk = ntuple(v->input[v+(cc-1)*V], V)
+            srt = Vec(sort_net(chunk...)) ::Vec{V*J,T}
+            vstorea(srt, output, 1+(cc-1)*V*J)
+        end
     end
 
-    # pairs = C
-    # l = L
+    new_input = reshape(output, V, J, K)
 
-    do_merge_pass(output, valloc(T, div(32,sizeof(T)), N*L*C), Val(C>>1), Val(N), Val(L<<1))
+    chunks_a = [(@view new_input[:,1:end,c*2-1]) for c in 1:K>>1]
+    chunks_b = [(@view new_input[:,1:end,c*2]) for c in 1:K>>1]
 
-    # display(reshape(input, 16, :))
-
-    # @inbounds while pairs > 1
-    #     K = N*l
-    #     pairs = pairs >> 1
-
-    #     chunks_a = [(@view input[ c*2*K+1   :    c*2*K+K]) for c in 0:pairs-1]
-    #     chunks_b = [(@view input[ c*2*K+1+K    :   c*2*K+2*K]) for c in 0:pairs-1]
-
-    #     bitonic_merge_interleaved(
-    #         ntuple(c->pointer(output, 1+(c-1)*2*K), pairs),
-    #         ntuple(c->pointer(output, 1+N+(c-1)*2*K), pairs),
-    #         ntuple(c->pointer(chunks_a[c], 1), pairs),
-    #         ntuple(c->pointer(chunks_b[c], 1), pairs),
-    #         Val(N)
-    #     )
-
-    #     for c in 1:pairs
-    #         chunks_a[c] = @view chunks_a[c][1+N:end]
-    #         chunks_b[c] = @view chunks_b[c][1+N:end]
-    #     end
-
-    #     # display(reshape(output, 16, :))
-    #     # display(chunks_a)
-    #     # display(chunks_b)
-
-    #     for iter in 1:(2*l-2)
-    #         next_inputs = Array{Ptr{T}}(undef, pairs)
-    #         # @show l, N, pairs
-    #         for c in 1:pairs
-    #             if length(chunks_a[c]) > 0 && (length(chunks_b[c]) == 0 || chunks_a[c][1] < chunks_b[c][1])
-    #                 next_inputs[c] = pointer(chunks_a[c], 1)
-    #                 chunks_a[c] = @view chunks_a[c][1+N:end]
-    #             else
-    #                 next_inputs[c] = pointer(chunks_b[c], 1)
-    #                 chunks_b[c] = @view chunks_b[c][1+N:end]
-    #             end
-    #         end
-
-    #         bitonic_merge_interleaved(
-    #             ntuple(c->pointer(output, 1+iter*N+(c-1)*2*K), pairs),
-    #             ntuple(c->pointer(output, 1+(iter+1)*N+(c-1)*2*K), pairs),
-    #             ntuple(c->pointer(output, 1+iter*N+(c-1)*2*K), pairs),
-    #             ntuple(c->next_inputs[c], pairs),
-    #             Val(N)
-    #         )
-
-    #         # display(reshape(output, 16,:))
-    #     # display(chunks_a)
-    #     # display(chunks_b)
-
-    #         # merge_pair2(output, input, pout, p1, p2, end1, end2, l,n,T)
-    #     end
-    #     l = l<<1
-    #     input, output = output, input
-    # end
-    # input
+    do_merge_pass(
+        new_input,
+        reshape(valloc(T, div(32,sizeof(T)), V*J*K), V, J<<1, K>>1),
+        chunks_a, chunks_b,
+        Val(V), Val(J<<1), Val(K>>1)
+    )
 end
 
+@inline function do_merge_pass(input::AbstractArray{T,3}, output::AbstractArray{T,3}, chunks_a, chunks_b,::Val{V}, ::Val{J}, ::Val{K}) where {T,V,J,K}
 
-function do_merge_pass(input::AbstractArray{T,1}, output::AbstractArray{T,1}, ::Val{C}, ::Val{N}, ::Val{L}) where {T,C,N,L}
-    # @show ("oi", C, N, L)
+    for c in 1:K
+        output[:,1,c] .= chunks_a[c][:,1]
+    end
+    next_inputs = [pointer(c) for c in chunks_b]
 
-    @inbounds if C == 0
-        input
-    else
-        K = N*L
+    bitonic_merge_interleaved(
+        output,
+        next_inputs,
+        Val(V), 1, Val(K)
+    )
 
-        # @show size(input)
-
-        chunks_a = [(@view input[ c*K + 1 : c*K + K>>1]) for c in 0:C-1]
-        chunks_b = [(@view input[ c*K + 1+K>>1 : c*K + K]) for c in 0:C-1]
-
-        bitonic_merge_interleaved(
-            ntuple(c->pointer(output, 1+(c-1)*K), C),
-            ntuple(c->pointer(output, 1+N+(c-1)*K), C),
-            ntuple(c->pointer(chunks_a[c], 1), C),
-            ntuple(c->pointer(chunks_b[c], 1), C),
-            Val(N)
-        )
-
-        for c in 1:C
-            chunks_a[c] = @view chunks_a[c][1+N:end]
-            chunks_b[c] = @view chunks_b[c][1+N:end]
-        end
-
-        # display(reshape(output, 16, :))
-        # display(chunks_a)
-        # display(chunks_b)
-
-        for iter in 1:(L-2)
-            next_inputs = Array{Ptr{T}}(undef, C)
-            # @show l, N, C
-            for c in 1:C
-                if length(chunks_a[c]) > 0 && (length(chunks_b[c]) == 0 || chunks_a[c][1] < chunks_b[c][1])
-                    next_inputs[c] = pointer(chunks_a[c], 1)
-                    chunks_a[c] = @view chunks_a[c][1+N:end]
-                else
-                    next_inputs[c] = pointer(chunks_b[c], 1)
-                    chunks_b[c] = @view chunks_b[c][1+N:end]
-                end
-            end
-
-            bitonic_merge_interleaved(
-                ntuple(c->pointer(output, 1+iter*N+(c-1)*K), C),
-                ntuple(c->pointer(output, 1+(iter+1)*N+(c-1)*K), C),
-                ntuple(c->pointer(output, 1+iter*N+(c-1)*K), C),
-                ntuple(c->next_inputs[c], C),
-                Val(N)
-            )
-
-            # display(reshape(output, 16,:))
-        # display(chunks_a)
-        # display(chunks_b)
-
-            # merge_pair2(output, input, pout, p1, p2, end1, end2, l,n,T)
-        end
-
-        do_merge_pass(output, input, Val(C>>1), Val(N), Val(L<<1))
+    for c in 1:K
+        chunks_a[c] = (@view (chunks_a[c][:,2:end]))
+        chunks_b[c] = (@view (chunks_b[c][:,2:end]))
     end
 
+    for iter in 2:(J-1)
+        for c in 1:K
+            if length(chunks_a[c]) > 0 && (length(chunks_b[c]) == 0 || chunks_a[c][1,1] < chunks_b[c][1,1])
+                next_inputs[c] = pointer(chunks_a[c], 1)
+                chunks_a[c] = (@view (chunks_a[c][:,2:end]))
+            else
+                next_inputs[c] = pointer(chunks_b[c], 1)
+                chunks_b[c] = (@view (chunks_b[c][:,2:end]))
+            end
+        end
+
+        bitonic_merge_interleaved(
+            output,
+            next_inputs,
+            Val(V), iter, Val(K)
+        )
+    end
+
+    if K == 1
+        reshape(output, :)
+    else
+
+        for c in 1:K>>1
+            chunks_a[c] = @view output[:,1:end,c*2-1]
+            chunks_b[c] = @view output[:,1:end,c*2]
+        end
+
+        do_merge_pass(
+            output,
+            reshape(input, V,J<<1,K>>1),
+            chunks_a, chunks_b,
+            Val(V), Val(J<<1), Val(K>>1)
+        )
+    end
 end

--- a/src/sort-array-medium.jl
+++ b/src/sort-array-medium.jl
@@ -39,16 +39,6 @@ function merge_vecs_tree(input::AbstractArray{T,A}, ::Val{C}, ::Val{N}, ::Val{L}
     end
 end
 
-function chipsort_medium_old(input::AbstractArray{T,A}, ::Val{C}, ::Val{N}, ::Val{L}) where {A,T,C,N,L}
-    output = valloc(T, div(32, sizeof(T)), size(input,1))
-    p=1
-    for chunk in merge_vecs_tree(input, Val(C), Val(N), Val(L))
-        vstore(chunk, output, p)
-        p+=N*L
-    end
-    output
-end
-
 
 function chipsort_merge_medium(input::AbstractArray{T,1}, ::Val{V}, ::Val{J}, ::Val{K}) where {T,V,J,K}
     output = valloc(T, div(32,sizeof(T)), V*J*K)

--- a/src/sort-array-medium.jl
+++ b/src/sort-array-medium.jl
@@ -88,28 +88,22 @@ end
 
 function merge_pair2(output, input, pout, p1, p2, end1, end2, L,N,T)
     h1 = vloada(Vec{N, T}, input, p1)
-    h2 = vloada(Vec{N, T}, input, p2)
 
-    out, state = bitonic_merge(h1, h2)
-    vstorea(out, output, pout)
+    state = bitonic_merge2(h1, pointer(input, p2), pointer(output, pout))
+
     pout += N
 
     p1 += N
     p2 += N
-    h1 = vloada(Vec{N, T}, input, p1)
-    h2 = vloada(Vec{N, T}, input, p2)
 
     for ii in 1:2*L-2
-        if p2>=end2 || p1 < end1 && h1[1] < h2[1]
-            out, state = bitonic_merge(state, h1)
+        if p2>=end2 || p1 < end1 && input[p1] < input[p2]
+            state = bitonic_merge2(state, pointer(input, p1), pointer(output, pout))
             p1 += N
-            h1 = vloada(Vec{N, T}, input, p1)
         else
-            out, state = bitonic_merge(state, h2)
+            state = bitonic_merge2(state, pointer(input, p2), pointer(output, pout))
             p2 += N
-            h2 = vloada(Vec{N, T}, input, p2)
         end
-        vstorea(out, output, pout)
         pout+=N
     end
     vstorea(state, output, pout)

--- a/src/sort-array-medium.jl
+++ b/src/sort-array-medium.jl
@@ -50,7 +50,7 @@ function chipsort_medium_old(input::AbstractArray{T,A}, ::Val{C}, ::Val{N}, ::Va
 end
 
 
-function chipsort_medium(input::AbstractArray{T,1}, ::Val{V}, ::Val{J}, ::Val{K}) where {T,V,J,K}
+function chipsort_merge_medium(input::AbstractArray{T,1}, ::Val{V}, ::Val{J}, ::Val{K}) where {T,V,J,K}
     output = valloc(T, div(32,sizeof(T)), V*J*K)
 
     if J>1

--- a/src/sort-array.jl
+++ b/src/sort-array.jl
@@ -1,6 +1,5 @@
 using SIMD
 
-
 sort_small_array(chunk::NTuple{L, Vec{N,T}}) where {L,N,T} =
     merge_vecs(transpose_vecs(sort_net(chunk...)...)...)
 
@@ -19,6 +18,28 @@ function sort_chunks(output, data::Array{T, 1}, ::Val{L}, ::Val{N}) where {L,N,T
     output
 end
 
+function sort_vecs!(data::AbstractVector{T}, ::Val{L}, ::Val{N}, ::Val{Transpose}) where {L,N,T,Transpose}
+    chunk_size = N*L
+    num_chunks = div(length(data), chunk_size)
+
+    for m in 1:num_chunks
+        # chunk = @view chunks[:, m]
+        # ntuple(l->vload(Vec{N, T}, chunk, 1+(l-1)*N), L)
+
+        chunk = ntuple(l->vload(Vec{N, T}, data, 1 + (m-1)*chunk_size + (l-1)*N), L)
+        sorted_vecs = if Transpose
+            transpose_vecs(sort_net(chunk...)...)
+        else
+            sort_net(chunk...)
+        end
+
+        for l in 1:L
+            vstorent(sorted_vecs[l], data, 1 + (m-1)*(N*L) + (l-1)*N)
+        end
+    end
+    nothing
+end
+
 function merge_chunks(output, data, ::Val{L}, ::Val{N}) where {L,N}
     chunks = reshape((@view data[:]), L*N, :)
     M = div(length(data), L*N)
@@ -32,7 +53,7 @@ function merge_chunks(output, data, ::Val{L}, ::Val{N}) where {L,N}
     output
 end
 
-function chipsort(data::Array{T, 1}, ::Val{N}, ::Val{L}, ::Val{N2}) where {T, N, L, N2}
+function chipsort(data::Vector{T}, ::Val{N}, ::Val{L}, ::Val{N2}) where {T, N, L, N2}
     chunk_size = L * N
     L2 = div(chunk_size, N2)
 

--- a/src/sort-array.jl
+++ b/src/sort-array.jl
@@ -23,9 +23,6 @@ function sort_vecs!(data::AbstractVector{T}, ::Val{L}, ::Val{N}, ::Val{Transpose
     num_chunks = div(length(data), chunk_size)
 
     for m in 1:num_chunks
-        # chunk = @view chunks[:, m]
-        # ntuple(l->vload(Vec{N, T}, chunk, 1+(l-1)*N), L)
-
         chunk = ntuple(l->vload(Vec{N, T}, data, 1 + (m-1)*chunk_size + (l-1)*N), L)
         sorted_vecs = if Transpose
             transpose_vecs(sort_net(chunk...)...)
@@ -33,8 +30,14 @@ function sort_vecs!(data::AbstractVector{T}, ::Val{L}, ::Val{N}, ::Val{Transpose
             sort_net(chunk...)
         end
 
-        for l in 1:L
-            vstorent(sorted_vecs[l], data, 1 + (m-1)*(N*L) + (l-1)*N)
+        if Transpose
+            for n in 1:N
+                vstorent(sorted_vecs[n], data, 1 + (m-1)*(N*L) + (n-1)*L)
+            end
+        else
+            for n in 1:L
+                vstorent(sorted_vecs[n], data, 1 + (m-1)*(N*L) + (n-1)*N)
+            end
         end
     end
     nothing

--- a/src/transpose-vecs.jl
+++ b/src/transpose-vecs.jl
@@ -1,6 +1,51 @@
 using SIMD
 
 
+"""In-place transpose of a 3 dimensianal array VKJ into VJK."""
+@generated function transpose!(data::AbstractVector{T}, ::Val{V}, ::Val{J}, ::Val{K}) where {T,V,J,K}
+    seeds = find_transpose_cycles(Val(K), Val(J))
+    :(transpose!(data, Val(V), Val(J), Val(K), $seeds))
+end
+
+@inline function transpose!(data::AbstractVector{T}, ::Val{V}, ::Val{J}, ::Val{K}, cycle_seeds) where {T,V,J,K}
+    kjm = K*J-1
+    @inbounds for c in cycle_seeds
+        a = c
+        base = pointer(data)
+        vlen = V * sizeof(T)
+        v1 = vloada(Vec{V, T}, base + vlen * a)
+        while true
+            pa = (a * K) % kjm
+            if pa == c break end
+            vpa = vload(Vec{V, T}, base + vlen * pa)
+            vstore(vpa, base + vlen * a)
+            a = pa
+        end
+        vstore(v1, base + vlen * a)
+    end
+    nothing
+end
+
+"""Find the cycle seeds to transpose a matrix with K rows and J columns into J columns and K rows."""
+function find_transpose_cycles(::Val{J}, ::Val{K}) where {J,K}
+    cycles = BitSet(1:K*J-2)
+    cycle_seeds = Int32[]
+    while length(cycles) > 0
+        a = popfirst!(cycles)
+        cmin = a
+        while true
+            pa = (a * K) % (K*J-1)
+            if pa ∉ cycles break end
+            cmin = min(cmin, pa)
+            setdiff!(cycles, Set([pa]))
+            a = pa
+        end
+        push!(cycle_seeds, cmin)
+    end
+    (cycle_seeds...,)
+end
+
+
 """
     transpose_vecs(input::Vararg{Vec{N,T}, L}) where {L,N,T}
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -2,5 +2,15 @@ using SIMD
 
 mylog(n) = if n == 1 0 else 1 + mylog(n>>1) end
 
-@inline concat(a::Vec{N,T}, b::Vec{M,T}) where {N,M,T} =  Vec((NTuple{N,T}(a)..., NTuple{M,T}(b)...))
+vallog(::Val{N}) where N = if N == 1 0 else 1 + vallog(Val(N>>1)) end
+
+#@inline concat(a::Vec{N,T}, b::Vec{M,T}) where {N,M,T} =  Vec((NTuple{N,T}(a)..., NTuple{M,T}(b)...))
 # @inline concat(a::Vec{N,T}, b::Vec{M,T}) where {N,M,T} = Vec(ntuple(j->if j<=N a[j] else b[j-N]end, N+M))
+
+@inline concat(a::Vararg{Vec{N,T},M}) where {N,M,T} = Vec(concat_tup(a...))
+@inline concat_tup(a::Vararg{Vec{N,T},M}) where {N,M,T} =
+    if length(a) == 1
+        NTuple{N,T}(a[1])
+    else
+        (NTuple{N,T}(a[1])..., concat_tup(a[2:end]...)...)
+    end

--- a/test/test-chipsort.jl
+++ b/test/test-chipsort.jl
@@ -2,6 +2,8 @@ using Test
 using ChipSort
 using SIMD
 
+include("testutils.jl")
+
 @testset "Array sorting" begin
 
 data = randa(Int32, 256)
@@ -10,6 +12,10 @@ data = randa(Int32, 256)
 data = randa(Int32, 2^13)
 ref = sort(data)
 @test chipsort_medium!(data,Val(8),Val(8),Val(128)) == ref
+
+data = randa(Int32, 2^13)
+ref = sort(data)
+@test chipsort_merge_medium(data,Val(8),Val(8),Val(128)) == ref
 
 data = tuple((Vec(tuple(sort(randa(Int8,4))...)) for _ in 1:4)...)
 stream_to_array(data) = [k[i] for i in 1:length(data), k in data][:]

--- a/test/test-chipsort.jl
+++ b/test/test-chipsort.jl
@@ -8,8 +8,9 @@ using SIMD
 data = rand(256)
 @test chipsort(data,Val(8),Val(8),Val(8)) == sort(data)
 
-data = rand(256)
-@test chipsort_medium(data,Val(4),Val(8),Val(8)) == sort(data)
+data = rand(2^13)
+ref = sort(data)
+@test chipsort_medium!(data,Val(4),Val(8)) == ref
 
 data = tuple((Vec(tuple(sort(rand(Int8,4))...)) for _ in 1:4)...)
 stream_to_array(data) = [k[i] for i in 1:length(data), k in data][:]

--- a/test/test-chipsort.jl
+++ b/test/test-chipsort.jl
@@ -17,6 +17,10 @@ data = randa(Int32, 2^13)
 ref = sort(data)
 @test chipsort_merge_medium(data,Val(8),Val(8),Val(128)) == ref
 
+data = randa(Int32, 2^6)
+ref = sort(data)
+@test chipsort_merge_medium(data,Val(8),Val(1),Val(8)) == ref
+
 data = tuple((Vec(tuple(sort(randa(Int8,4))...)) for _ in 1:4)...)
 stream_to_array(data) = [k[i] for i in 1:length(data), k in data][:]
 @test stream_to_array(merge_vecs_tree(data...)) == sort(stream_to_array(data))

--- a/test/test-chipsort.jl
+++ b/test/test-chipsort.jl
@@ -11,18 +11,24 @@ data = randa(Int32, 256)
 
 data = randa(Int32, 2^13)
 ref = sort(data)
-@test chipsort_medium!(data,Val(8),Val(8),Val(128)) == ref
+@test chipsort_medium!(data, Val(8), Val(8), Val(128)) == ref
 
 data = randa(Int32, 2^13)
 ref = sort(data)
 @test chipsort_merge_medium(data,Val(8),Val(8),Val(128)) == ref
 
+data = randa(Int32, 2^7)
+ref = sort(data)
+@test combsort!(copy(data)) == ref
+@test combsort!(data, 2^6) == ref
+
 data = randa(Int32, 2^6)
 ref = sort(data)
 @test chipsort_merge_medium(data,Val(8),Val(1),Val(8)) == ref
 
-data = tuple((Vec(tuple(sort(randa(Int8,4))...)) for _ in 1:4)...)
-stream_to_array(data) = [k[i] for i in 1:length(data), k in data][:]
+data = tuple((Vec(tuple(sort(randa(Int8,8))...)) for _ in 1:4)...)
+stream_to_array(data) = [k[i] for k in data for i in 1:length(k)][:]
 @test stream_to_array(merge_vecs_tree(data...)) == sort(stream_to_array(data))
+@test stream_to_array(merge_vecs_tree(stream_to_array(data), Val(4), Val(4), Val(2))) == sort(stream_to_array(data))
 
 end

--- a/test/test-transpose.jl
+++ b/test/test-transpose.jl
@@ -3,11 +3,32 @@ using Test
 using ChipSort
 using SIMD
 
+include("testutils.jl")
 
 @testset "Transpose" begin
 
 # types_to_test = [UInt8, UInt16, UInt32, UInt64, Float32, Float64]
 types_to_test = [UInt16, Float64]
+
+function test_transpose(T, V, J, K)
+    data = randa(T, V*J*K)
+    sol = permutedims(reshape(data, V, K, J), [1,3,2])[:]
+    # seed=find_transpose_cycles(Val(J), Val(K))
+    # transpose!(aa, Val(V), Val(J), Val(K), seed)
+    transpose!(data, Val(V), Val(J), Val(K))
+    @test sol == data
+end
+
+@testset for T in types_to_test
+    for V in 2 .^ (1:2:5)
+        for J in 2 .^ (1:2:5)
+            for K in 2 .^ (2:4:8)
+                test_transpose(T, V, J, K)
+            end
+        end
+    end
+end
+
 
 function test_transpose_vecs(T, N, L)
     uu = ntuple(l->Vec(tuple([convert(T, mod(l*N+n-N, 2^(8*T.size-2))) for n in 1:N]...)), L)

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -1,0 +1,5 @@
+function randa(T, K)
+    data = valloc(T, div(32, sizeof(T)), K)
+    data .= rand(T, K)
+    data
+end


### PR DESCRIPTION
Improved performance of medium-szied arrays (that can fit on cache L! or L2) using vectorized comb sort.

Just plain combsort turns out to have a greatperformance already, beating the standard library with an almost 50% speedup.